### PR TITLE
fix: show update output in CLI

### DIFF
--- a/distrodeck.py
+++ b/distrodeck.py
@@ -135,7 +135,10 @@ def run_warn(cmd, title: str) -> subprocess.CompletedProcess:
 def run_warn_live(cmd, title: str) -> subprocess.CompletedProcess:
     if in_dialog_mode():
         return run(cmd, check=False)
-    return run_warn(cmd, title)
+    result = run(cmd, check=False)
+    if result.returncode != 0:
+        warn(f"{title} failed.")
+    return result
 
 
 def get_log_dir() -> Path:
@@ -3611,12 +3614,12 @@ def build_parser() -> argparse.ArgumentParser:
         description="Export and restore packages before distro upgrades.",
     )
     parser.add_argument(
-        "-v",
+        "-V",
         "--verbose",
         action="store_true",
         help="Enable verbose output where applicable",
     )
-    parser.add_argument("--version", action="version", version=VERSION)
+    parser.add_argument("-v", "--version", action="version", version=VERSION)
     sub = parser.add_subparsers(dest="command", required=True)
 
     export_cmd = sub.add_parser("export", help="Export installed packages and sources")


### PR DESCRIPTION
This pull request updates command-line argument handling and error reporting in `distrodeck.py` to improve clarity and consistency. The changes focus on fixing argument flag assignments and enhancing feedback when commands fail.

**Command-line argument improvements:**

* Swapped the short flags for verbose and version options in the argument parser: `-V` is now used for `--verbose`, and `-v` is used for `--version`, aligning with common CLI conventions.

**Error handling enhancements:**

* Updated the `run_warn_live` function to directly warn the user when a command fails, providing clearer feedback in non-dialog mode.