### PR TITLE
Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,3 +296,11 @@ Before publishing to a PPA, update `debian/changelog` and `debian/control` with 
 ## Contributing
 
 Keep the script POSIX-friendly where possible and avoid adding heavy dependencies.
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/distrodeck.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/distrodeck.svg before updating the README.
- Ran git diff --check for the README change.