### PR TITLE
ci: fix Main workflow startup_failure (grant contents: write)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,14 @@ on:
 
 jobs:
   deb:
+    # deb-build@production declares `permissions: contents: write` to upload
+    # the built .deb to GitHub Releases. A called reusable workflow cannot be
+    # granted more permission than the caller, and this repo's default workflow
+    # token is read-only, so without this grant the run is rejected at startup
+    # (startup_failure). Scoped to this job only (least privilege) since the
+    # other jobs' reusable workflows don't request write.
+    permissions:
+      contents: write
     uses: nikolareljin/ci-helpers/.github/workflows/deb-build.yml@production
     with:
       working_directory: "."


### PR DESCRIPTION
## Problem

The **Main** packaging workflow startup-failed on the merge of #36:
[run 28143982327](https://github.com/nikolareljin/distrodeck/actions/runs/28143982327) → `startup_failure` (GitHub rejected the run before any job started; no logs/annotations are exposed for this class of failure).

## Root cause

`main.yml` calls reusable workflows from `nikolareljin/ci-helpers@production`. The **2026-06-22** ci-helpers update (0.15.0) added an "upload built artifact to GitHub release" step to `deb-build.yml`, which now declares:

```yaml
permissions:
  contents: write
```

A called reusable workflow **cannot be granted more permission than the caller**. This repo's *default workflow token permission is read-only* (`default_workflow_permissions: read`), and `main.yml` set no `permissions:` block — so the caller could only offer `contents: read`, less than the `contents: write` the reusable workflow requests. GitHub rejects this at startup → `startup_failure`.

This is why prior runs (last one 2026-04-28, before the ci-helpers change) *started* and merely failed at runtime, while the post-update run can't start at all.

## How it was isolated

Reproduced on a throwaway branch by progressively probing a local reusable workflow:

| Probe | Result |
|---|---|
| boolean `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` | success (ruled out) |
| `actions/checkout@v7` + `upload-artifact@v7` + softprops SHA | success (ruled out) |
| reusable workflow declaring `permissions: contents: write`, caller grants nothing | **startup_failure** ✓ |
| same, but caller grants `permissions: contents: write` | success ✓ |

## Fix

Add a `permissions: contents: write` block to the **caller** (`main.yml`) so the reusable packaging workflows' requested permissions are satisfied. **All `ci-helpers` references remain pinned to `@production`** (unchanged — 5/5 intact); only the caller's token scope changed.